### PR TITLE
RDKCOM-1600 : Generic data-model

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -1,0 +1,3963 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dm:document spec="http://dimark.com" xmlns:dm="urn:broadband-forum-org:cwmp:datamodel-1-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:broadband-forum-org:cwmp:datamodel-1-2 data/cwmp-datamodel-1-2-dimark.xsd cwmp-datamodel-1-2-dimark.xsd">
+  <model name="data-model">
+    <object base="Device." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="InterfaceStackNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+    </object>    
+    <object base="Device.DeviceInfo." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Manufacturer" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ManufacturerOUI" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ModelName" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Description" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="TR-181, TR-135 and RDK specific Datamodel Configuration"/>
+        </syntax>
+      </parameter>
+      <parameter base="ProductClass" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="Accelerator"/>
+        </syntax>
+      </parameter>
+      <parameter base="SerialNumber" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="HardwareVersion" access="readOnly" notification="4" alwaysInclude="true" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SoftwareVersion" access="readOnly" notification="4" alwaysInclude="true" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="AdditionalSoftwareVersion" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ProvisioningCode" access="readWrite" notification="4" alwaysInclude="true" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="UpTime" access="readOnly" notification="0" maxNotification="0" rebootIdx="0" initIdx="1" getIdx="124" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="FirstUseDate" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="VendorLogFileNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+      <parameter base="SupportedDataModelNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="316" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ProcessorNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+
+      <parameter base="X_RDKCENTRAL-COM_RDKVersion" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_PreferredGatewayType" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareDownloadStatus" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareFilename" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareToDownload" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareDownloadProtocol" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareDownloadURL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareDownloadNow" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareDownloadUseCodebig" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareDownloadPercent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <int/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_FirmwareUpdateState" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_Reset" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_BootTime" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <unsignedInt/> </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enabled" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DiscoveryEnabled" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="DiscoveredDeviceCnt" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="PairedDeviceCnt" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ConnectedDeviceCnt" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="GetDeviceInfo" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="LimitBeaconDetection" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>	  
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth.DiscoveredDevice.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DeviceID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DeviceType" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Paired" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth.PairedDevice.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DeviceID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DeviceType" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Connected" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth.ConnectedDevice.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DeviceID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DeviceType" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Active" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth.DeviceInfo." access="readOnly" minEntries="1" maxEntries="1">
+      <parameter base="DeviceID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Profile" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Manufacturer" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+      <parameter base="MAC" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="RSSI" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+      <parameter base="SignalStrength" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth.BLE." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth.BLE.Tile." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xBlueTooth.BLE.Tile.Cmd." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Request" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature." access="readOnly" minEntries="1" maxEntries="1">
+    <parameter base="ViperPPUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+      <parameter base="RoamTrigger" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+      <parameter base="BLERadio" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Preference." access="readOnly" minEntries="1" maxEntries="1">
+      <parameter base="URL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>	 
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.SDCARD_SCRATCHPAD." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+     </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.TelemetryEndpoint." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="URL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.USB_AutoMount." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="AccountID" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+          <string/>
+       </syntax>
+     </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.OTT_Token." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <boolean/>
+       </syntax>
+     </parameter>
+    </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.LXC." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0"/>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.LXC.Netflix." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+       </parameter>
+      </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.EncryptCloudUpload." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XRPollingConfiguration." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <boolean/>
+       </syntax>
+      </parameter>
+      <parameter base="Default" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+      </parameter>
+      <parameter base="XR11v2" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+      </parameter>
+      <parameter base="XR15v1" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+      </parameter>
+      <parameter base="XR15v2" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+      </parameter>
+      <parameter base="XR19v1" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XRmacPolling." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <boolean/>
+       </syntax>
+      </parameter>
+      <parameter base="macPollingInterval" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <int/>
+       </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XRPairing." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="ASBEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <boolean/>
+       </syntax>
+      </parameter>
+      <parameter base="ASBDerivationMethod" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <int/>
+       </syntax>
+      </parameter>
+      <parameter base="ASBFailThreshold" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <int/>
+       </syntax>
+      </parameter>
+     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RF4CE." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="AudioProfileTarget" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <int/>
+       </syntax>
+      </parameter>
+      <parameter base="OpusEncoderParams" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AAMP_CFG." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="b64Config" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DashPlaybackExclusions" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DashPlaybackInclusions" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FOG_CFG." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="b64Config" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AllowOpenPorts." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enabled" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UniqueTelemetryId." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UniqueTelemetryId." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="TagString" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UniqueTelemetryId." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="TimingInterval" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+      <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.IPRemotePort." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_XRPolling." access="readWrite" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Action" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Tr069DoSLimit." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Threshold" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+        <string/>
+       </syntax>
+     </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.HdrEnable." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+        <parameter base="Enable" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+            <syntax>
+                <boolean/>
+            </syntax>
+        </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UhdEnable." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+        <parameter base="Enable" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+            <syntax>
+                <boolean/>
+            </syntax>
+        </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.LoudnessEquivalence." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+        <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+            <syntax>
+                <boolean/>
+            </syntax>
+        </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.HDMICECDaemon." minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+        <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+            <syntax>
+                <boolean/>
+            </syntax>
+        </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XDial." minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+        <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+            <syntax>
+                <boolean/>
+            </syntax>
+        </parameter>
+        <parameter base="AppList" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+            <syntax>
+                <string/>
+            </syntax>
+        </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.KeepReceiverProcessOnStandby." minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+        <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+            <syntax>
+                <boolean/>
+          </syntax>
+        </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CECLocalLogic." access="readOnly"  minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+        <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+            <syntax>
+                <boolean/>
+          </syntax>
+        </parameter>
+    </object>
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XRRemoteAsLinuxDevice." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="Enable" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+           <syntax>
+               <boolean/>
+           </syntax>
+       </parameter>
+   </object>
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DolbyVision." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="Enable" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+           <syntax>
+               <boolean/>
+           </syntax>
+       </parameter>
+   </object>
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BLE." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Discovery" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BLE.Tile." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="ReportingURL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BLE.Tile.Ring." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+       <syntax>
+         <boolean/>
+       </syntax>
+     </parameter>
+   </object>
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.EnableHttpCDL." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+           <syntax>
+               <boolean/>
+           </syntax>
+       </parameter>
+   </object>
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CDLDM." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="CDLModuleUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+           <syntax>
+               <string/>
+           </syntax>
+       </parameter>
+   </object>
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.eMMCMitigation." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="Disable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+           <syntax>
+               <boolean/>
+           </syntax>
+       </parameter>
+   </object>
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.eMMCFirmware." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="Version" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+          <syntax>
+            <string/>
+          </syntax>
+       </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNSStrictOrder." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BTR." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BTR.AudioIn." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BTSplitAudio." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Language" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+       </parameter>
+    </object>
+    <object base="Device.DeviceInfo.SupportedDataModel." access="readOnly" minEntries="1" maxEntries="unbounded"/>
+    <object base="Device.DeviceInfo.SupportedDataModel.1." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="URL" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="3901" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="URN" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="3902" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Features" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="3903" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.SupportedDataModel.2." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="URL" access="readWrite" notification="0" maxNotification="2" rebootIdx="1" initIdx="1" getIdx="3901" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="URN" access="readWrite" notification="0" maxNotification="2" rebootIdx="1" initIdx="1" getIdx="3902" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Features" access="readWrite" notification="0" maxNotification="2" rebootIdx="1" initIdx="1" getIdx="3903" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.MemoryStatus." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Total" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Free" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+    </object>        
+    <object base="Device.DeviceInfo.ProcessStatus." access="readOnly" minEntries="1" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="CPUUsage" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ProcessNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+    </object>      
+ 	<object base="Device.DeviceInfo.ProcessStatus.Process.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="PID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Command" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Size" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Priority" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="CPUTime" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter> 	
+      <parameter base="State" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>   
+    <object base="Device.DeviceInfo.Processor.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Architecture" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="BootStatus" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+       <parameter base="CPUTemp" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_IPRemoteSupport." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="IPAddr" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="MACAddr" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt." access="readOnly" minEntries="1" maxEntries="unbounded"/> 
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Logging." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="xOpsDMUploadLogsNow" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="xOpsDMLogsUploadStatus" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.ReverseSSH." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="xOpsReverseSshTrigger" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="xOpsReverseSshArgs" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="xOpsReverseSshStatus" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.ForwardSSH." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <boolean/>
+         </syntax>
+        </parameter>
+      </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC." access="readOnly" minEntries="1" maxEntries="1"/>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.AppCommander."  access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="DestroyAppsToClearMem" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Control."  access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="RetrieveNow" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <unsignedInt/> </syntax>
+      </parameter>
+      <parameter base="ClearDB" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+      <parameter base="ClearDBEnd" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+      <parameter base="ConfigSetTime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <unsignedInt/> </syntax>
+      </parameter>
+      <parameter base="ConfigSetHash" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="ConfigChangeTime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <unsignedInt/> </syntax>
+      </parameter>
+      <parameter base="XconfSelector" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="XconfUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+       </parameter>
+     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.RPC." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="RebootNow" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.ManagementServer." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="EnableCWMP" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+	    <syntax>
+          <boolean/>
+        </syntax>        
+      </parameter>
+      <parameter base="URL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Username" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Password" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PeriodicInformEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="PeriodicInformInterval" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="300"/>
+        </syntax>
+      </parameter>
+      <parameter base="PeriodicInformTime" access="readWrite"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="ParameterKey" access="readOnly" notification="4" alwaysInclude="true" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ConnectionRequestURL" access="readOnly" notification="4" alwaysInclude="true" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="117" setIdx="-1">
+        <syntax>
+        <string/>
+        </syntax>
+	  </parameter>
+      <parameter base="ConnectionRequestUsername" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>      
+      </parameter>
+      <parameter base="ConnectionRequestPassword" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="UpgradesManaged" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="KickURL" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DownloadProgressURL" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>            
+      <parameter base="DefaultActiveNotificationThrottle" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="600"/>
+        </syntax>
+      </parameter>
+      <parameter base="CWMPRetryMinimumWaitInterval" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="CWMPRetryIntervalMultiplier" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+      <parameter base="UDPConnectionRequestAddress" access="readOnly" notification="0" maxNotification="3" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="STUNEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="STUNServerAddress" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="STUNServerPort" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="3478"/>
+        </syntax>
+      </parameter>
+      <parameter base="STUNUsername" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="STUNPassword" access="readWrite" notification="0" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="STUNMaximumKeepAlivePeriod" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <int/>
+          <default type="factory" value="80"/>
+        </syntax>
+      </parameter>
+      <parameter base="STUNMinimumKeepAlivePeriod" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="30"/>
+        </syntax>
+      </parameter>
+      <parameter base="NATDetected" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="AliasBasedAddressing" access="readOnly" notification="4" alwaysInclude="true" maxNotification="3" rebootIdx="0" initIdx="130" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="InstanceMode" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="131">
+        <syntax>
+          <string/>
+          <default type="factory" value="InstanceNumber"/>
+        </syntax>
+      </parameter>
+      <parameter base="AutoCreateInstances" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="132">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>   
+	</object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.hwHealthTest." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="ExecuteTest" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+      <parameter base="Results" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.hwHealthTest." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="EnablePeriodicRun" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="PeriodicRunFrequency" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="cpuThreshold" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="dramThreshold" access="writeOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="-1" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+	<object base="Device.Time." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16600" setIdx="16600">
+        <syntax>
+          <boolean/>
+        </syntax>      
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16601" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NTPServer4" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16605" setIdx="16605">
+        <syntax>
+          <string/>
+        </syntax>      
+      </parameter>
+      <parameter base="NTPServer5" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16606" setIdx="16606">
+        <syntax>
+          <string/>
+        </syntax>      
+      </parameter>
+      <parameter base="CurrentLocalTime" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16607" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>      
+      </parameter>
+      <parameter base="LocalTimeZone" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16608" setIdx="16608">
+        <syntax>
+          <string/>
+        </syntax>      
+      </parameter>
+    </object>
+    <object base="Device.InterfaceStack.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="HigherLayer" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="LowerLayer" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>    
+	<object base="Device.Ethernet." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="InterfaceNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      
+      </parameter>
+      <parameter base="LinkNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>      
+      </parameter>
+    </object>
+    <object base="Device.Ethernet.Interface.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+       <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+	  <parameter base="LastChange" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="LowerLayers" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Upstream" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>      
+      <parameter base="MACAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="MaxBitRate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+      <parameter base="DuplexMode" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Ethernet.Interface.{i}.Stats." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"> 
+	  <parameter base="BytesSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="BytesReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="PacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="PacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>     
+	  <parameter base="ErrorsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+	  <parameter base="ErrorsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="UnicastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="UnicastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="DiscardPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="DiscardPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+	  <parameter base="MulticastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="MulticastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="BroadcastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="BroadcastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="UnknownProtoPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>   
+ 	<object base="Device.Ethernet.Link.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="Down"/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+	  <parameter base="LowerLayers" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+          <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+      <parameter base="MACAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>      
+    </object>   
+    <object base="Device.IP." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="IPv4Capable" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+	 <syntax>
+	   <boolean/>
+	</syntax>
+      </parameter>
+      <parameter base="IPv4Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+	<syntax>
+	  <boolean/>
+	</syntax>
+      </parameter>
+      <parameter base="IPv4Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+	<syntax>
+	  <string/>
+	</syntax>
+      </parameter>
+      <parameter base="ULAPrefix" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="18001">
+	<syntax>
+	  <string/>
+	</syntax>
+      </parameter>
+      <parameter base="InterfaceNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+	<syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ActivePortNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Interface.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="IPv4Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="IPv6Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ULAEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="LastChange" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="LowerLayers" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+          <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+      <parameter base="Router" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Reset" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="MaxMTUSize" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Type" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Loopback" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="IPv4AddressNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="IPv6AddressNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="IPv6PrefixNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="AutoIPEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Interface.{i}.IPv4Address.{i}." access="readOnly" minEntries="1" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="IPAddress" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SubnetMask" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="AddressingType" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Interface.{i}.IPv6Address.{i}." access="readOnly" minEntries="1" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="IPAddressStatus" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="IPAddress" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Origin" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Prefix" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PreferredLifetime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="ValidLifetime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="Anycast" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Interface.{i}.IPv6Prefix.{i}." access="readOnly" minEntries="1" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PrefixStatus" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Prefix" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Origin" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="StaticType" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ParentPrefix" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ChildPrefixBits" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="OnLink" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Autonomous" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="PreferredLifetime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="ValidLifetime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Interface.{i}.Stats." access="readOnly" minEntries="1" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="BytesSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="BytesReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="PacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="PacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="ErrorsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ErrorsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="UnicastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="UnicastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="DiscardPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="DiscardPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="MulticastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="MulticastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="BroadcastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="BroadcastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+      <parameter base="UnknownProtoPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.ActivePort.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="LocalIPAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="LocalPort" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="RemoteIPAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="RemotePort" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Diagnostics." access="readOnly" minEntries="1" maxEntries="unbounded"/>
+    <object base="Device.IP.Diagnostics.IPPing." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="DiagnosticsState" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16000" setIdx="16000">
+        <syntax>
+          <string/>
+          <default type="factory" value="None"/>
+        </syntax>
+      </parameter>
+      <parameter base="Interface" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16001" setIdx="16001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Host" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16002" setIdx="16002">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NumberOfRepetitions" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16003" setIdx="16003">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Timeout" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16004" setIdx="16004">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="DataBlockSize" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16005" setIdx="16005">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="DSCP" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16006" setIdx="16006">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="SuccessCount" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16007" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="FailureCount" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16008" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="AverageResponseTime" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16009" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="MinimumResponseTime" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16010" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="MaximumResponseTime" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16011" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Diagnostics.X_RDKCENTRAL-COM_SpeedTest." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Enable_Speedtest" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Run" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Argument" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ClientType" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Authentication" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Diagnostics.TraceRoute." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="DiagnosticsState" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16500" setIdx="16500">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Interface" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16501" setIdx="16501">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Host" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16502" setIdx="16502">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NumberOfTries" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16503" setIdx="16503">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Timeout" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16504" setIdx="16504">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="DataBlockSize" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16505" setIdx="16505">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="DSCP" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16506" setIdx="16506">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="MaxHopCount" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16507" setIdx="16507">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ResponseTime" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16508" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="RouteHopsNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16509" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Diagnostics.TraceRoute.RouteHops.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Host" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16510" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="HostAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16511" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ErrorCode" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16512" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="RTTimes" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="16512" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Diagnostics.DownloadDiagnostics." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="DiagnosticsState" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16100">
+        <syntax>
+          <string/>
+          <default type="factory" value="None"/>
+        </syntax>
+      </parameter>
+      <parameter base="Interface" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16101">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DownloadURL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16102">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DownloadTransports" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="HTTP,FTP"/>
+        </syntax>
+      </parameter>
+      <parameter base="DSCP" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16103">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="EthernetPriority" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16104">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ROMTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="BOMTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="EOMTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="TestBytesReceived" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="TotalBytesReceived" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="TCPOpenRequestTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="TCPOpenResponseTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Diagnostics.UploadDiagnostics." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="DiagnosticsState" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16200">
+        <syntax>
+          <string/>
+          <default type="factory" value="None"/>
+        </syntax>
+      </parameter>
+      <parameter base="Interface" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16201">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="UploadURL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16202">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="UploadTransports" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="HTTP,FTP"/>
+        </syntax>
+      </parameter>
+      <parameter base="DSCP" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16203">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="EthernetPriority" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16204">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="TestFileLength" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16205">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="ROMTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="BOMTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="EOMTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="TotalBytesSent" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="TCPOpenRequestTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="TCPOpenResponseTime" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.IP.Diagnostics.UDPEchoConfig." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16400">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="Interface" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16401">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SourceIPAddress" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="UDPPort" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="16402">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="EchoPlusEnabled" access="readWrite" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="EchoPlusSupported" access="readOnly" notification="1" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="PacketsReceived" access="readOnly" notification="0" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="PacketsResponded" access="readOnly" notification="0" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="BytesReceived" access="readOnly" notification="0" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="BytesResponded" access="readOnly" notification="0" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="TimeFirstPacketReceived" access="readOnly" notification="0" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+      <parameter base="TimeLastPacketReceived" access="readOnly" notification="0" maxNotification="1" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <dateTime/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="STBServiceNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService." access="readOnly" minEntries="1" maxEntries="unbounded"/>
+    <object base="Device.Services.STBService.1." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+     </object>
+    <object base="Device.Services.STBService.1.Capabilities." access="readOnly" minEntries="1" maxEntries="1" />
+    <object base="Device.Services.STBService.1.Capabilities.VideoDecoder." access="readOnly" minEntries="1" maxEntries="1" >
+      <parameter base="VideoStandards" access="readOnly"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <list/>
+            <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Capabilities.VideoDecoder.X_RDKCENTRAL-COM_MPEGHPart2." access="readOnly" minEntries="1" maxEntries="1" >
+      <parameter base="ProfileLevelNumberOfEntries" access="readOnly"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Capabilities.VideoDecoder.X_RDKCENTRAL-COM_MPEGHPart2.ProfileLevel." access="readOnly"  minEntries="1" maxEntries="unbounded" />
+    <object base="Device.Services.STBService.1.Capabilities.VideoDecoder.X_RDKCENTRAL-COM_MPEGHPart2.ProfileLevel.1." access="readOnly" numEntriesParameter="ProfileLevelNumberOfEntries" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0" >
+      <parameter base="Alias" access="readOnly" activeNotify="canDeny" notification="0"  maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Profile" access="readOnly"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Level" access="readOnly"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="MaximumDecodingCapability" access="readOnly"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt>
+            <units value="Kilobits per second"/>
+          </unsignedInt>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Capabilities.HDMI." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="0" delObjIdx="0" >
+      <parameter base="SupportedResolutions" access="readOnly"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <list/>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+     <object base="Device.Services.STBService.1.Components." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="VideoDecoderNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="AudioOutputNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="VideoOutputNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="HDMINumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Components.VideoDecoder." access="readOnly" minEntries="1" maxEntries="unbounded"/>
+    <object base="Device.Services.STBService.1.Components.VideoDecoder.1." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ContentAspectRatio" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_MPEGHPart2" access="readOnly"  notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string>
+            <size maxLength="256"/>
+            <pathRef refType="strong" targetParent=".Capabilities.VideoDecoder.X_RDKCENTRAL-COM_MPEGHPart2.ProfileLevel." targetType="row"/>
+          </string>
+        </syntax>
+      </parameter>
+    </object>
+	<object base="Device.Services.STBService.1.Components.AudioOutput." access="readOnly" minEntries="1" maxEntries="unbounded"/>
+    <object base="Device.Services.STBService.1.Components.AudioOutput.1." access="readOnly" minEntries="1" maxEntries="unbounded">
+	<parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+    </parameter>
+	<parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="The Audio Output Component"/>
+        </syntax>
+      </parameter>
+      <parameter base="AudioFormat" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>          
+        </syntax>
+      </parameter>
+      <parameter base="AudioLevel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <unsignedInt/>          
+        </syntax>
+      </parameter>
+      <parameter base="CancelMute" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+    </object>		
+    <object base="Device.Services.STBService.1.Components.VideoOutput." access="readOnly" minEntries="1" maxEntries="unbounded"/>
+    <object base="Device.Services.STBService.1.Components.VideoOutput.1." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+	  <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="VideoFormat" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="AspectRatioBehaviour" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="DisplayFormat" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="HDCP" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Components.HDMI." access="readOnly" minEntries="1" maxEntries="unbounded"/>
+    <object base="Device.Services.STBService.1.Components.HDMI.1." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+	  <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ResolutionMode" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ResolutionValue" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Components.HDMI.1.DisplayDevice." access="readOnly" minEntries="1" maxEntries="unbounded">
+	  <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="EEDID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SupportedResolutions" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PreferredResolution" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="VideoLatency" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="CECSupport" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="AutoLipSyncSupport" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="HDMI3DPresent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Components.X_RDKCENTRAL-COM_eMMCFlash." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="Manufacturer" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="Model" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="LotID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="SerialNumber" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="Capacity" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <unsignedInt/> </syntax>
+      </parameter>
+      <parameter base="ReadOnly" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+      <parameter base="TSBQualified" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+      <parameter base="LifeElapsedB" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <int/> </syntax> 
+      </parameter>
+      <parameter base="LifeElapsedA" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <int/> </syntax>
+      </parameter>
+      <parameter base="PreEOLStateSystem" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="PreEOLStateEUDA" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="PreEOLStateMLC" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="FirmwareVersion" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="DeviceReport" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax> <string/> </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Components.X_RDKCENTRAL-COM_RF4CE." access="readOnly" minEntries="1" maxEntries="unbounded">
+      <parameter base="rf4ceVersionInfo" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>          
+        </syntax>
+      </parameter>
+      <parameter base="rf4cePANID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>          
+        </syntax>
+      </parameter>
+	  <parameter base="rf4ceMACAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>          
+        </syntax>
+      </parameter>
+	  <parameter base="rf4ceActiveChannel" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>          
+        </syntax>
+      </parameter>
+  	  <parameter base="rf4ceNetworkAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>          
+        </syntax>
+      </parameter>
+  	  <parameter base="rf4cePairedRemotesNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>          
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.Services.STBService.1.Components.X_RDKCENTRAL-COM_RF4CE.Remote." access="readOnly" minEntries="1" maxEntries="unbounded"/>                                   
+    <object base="Device.Services.STBService.1.Components.X_RDKCENTRAL-COM_RF4CE.Remote.1." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="MACAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>          
+        </syntax>
+      </parameter>
+	  <parameter base="VersionInfoSW" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>          
+        </syntax>
+      </parameter>	
+	  <parameter base="VersionInfoHW" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>          
+        </syntax>
+      </parameter>	
+	  <parameter base="RemoteId" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>	
+	  <parameter base="RemoteType" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>          
+        </syntax>
+      </parameter>	
+	  <parameter base="BatteryReplacement" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>          
+        </syntax>
+      </parameter>	
+	  <parameter base="ImpendingDoom" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>          
+        </syntax>
+      </parameter>	
+	  <parameter base="BatteryLevelLoaded" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>	
+	  <parameter base="BatteryLevelUnloaded" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>	
+	  <parameter base="BatteryPercentage" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>	
+	  <parameter base="SignalStrength" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>	
+	  <parameter base="LinkQuality" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>	
+	  <parameter base="NetworkAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>	
+    </object>	
+        <object base="Device.WiFi." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="RadioNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="SSIDNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="AccessPointNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="EndPointNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="X_RDKCENTRAL-COM_WiFiEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+ 	<object base="Device.WiFi.Radio.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter> 
+	  <parameter base="LastChange" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="LowerLayers" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Upstream" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+	  <parameter base="MaxBitRate" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="SupportedFrequencyBands" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="OperatingFrequencyBand" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SupportedStandards" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="OperatingStandards" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PossibleChannels" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ChannelsInUse" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+	  <parameter base="Channel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="AutoChannelSupported" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="AutoChannelEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+	  <parameter base="AutoChannelRefreshPeriod" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="OperatingChannelBandwidth" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ExtensionChannel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="GuardInterval" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="MCS" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+      <parameter base="TransmitPowerSupported" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="TransmitPower" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+      <parameter base="IEEE80211hSupported" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="IEEE80211hEnabled" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="RegulatoryDomain" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.WiFi.Radio.{i}.Stats." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"> 
+	  <parameter base="BytesSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="BytesReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter> 
+	  <parameter base="PacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="PacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="ErrorsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+	  <parameter base="ErrorsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="DiscardPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="DiscardPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Noise" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>      
+    </object>
+	<object base="Device.WiFi.SSID.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Name" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter> 
+	  <parameter base="LastChange" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="LowerLayers" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+          <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+      <parameter base="BSSID" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="MACAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SSID" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.WiFi.SSID.{i}.Stats." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"> 
+	  <parameter base="BytesSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="BytesReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="PacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="PacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="ErrorsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="ErrorsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="UnicastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="UnicastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="DiscardPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="DiscardPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="MulticastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>
+	  <parameter base="MulticastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="BroadcastPacketsSent" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="BroadcastPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedLong/>
+        </syntax>
+      </parameter>      
+	  <parameter base="UnknownProtoPacketsReceived" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+    </object>
+	<object base="Device.WiFi.AccessPoint.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="Disable"/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SSIDReference" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+          <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+      <parameter base="SSIDAdvertisementEnabled" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>      
+	  <parameter base="RetryLimit" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="WMMCapability" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="UAPSDCapability" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="WMMEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="UAPSDEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+	  <parameter base="AssociatedDeviceNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>      
+    <object base="Device.WiFi.AccessPoint.{i}.Security." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="ModesSupported" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ModeEnabled" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>      
+      <parameter base="WEPKey" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <hexBinary/>
+        </syntax>
+      </parameter>
+      <parameter base="PreSharedKey" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <hexBinary/>
+        </syntax>
+      </parameter>
+      <parameter base="KeyPassphrase" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="RekeyingInterval" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="3600"/>
+        </syntax>
+      </parameter>
+      <parameter base="RadiusServerIPAddr" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="RadiusServerPort" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="1812"/>
+        </syntax>
+      </parameter>
+      <parameter base="RadiusSecret" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.WiFi.AccessPoint.{i}.WPS." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="ConfigMethodsSupported" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ConfigMethodsEnabled" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+ 	<object base="Device.WiFi.AccessPoint.{i}.AssociatedDevice.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="MACAddress" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="AuthenticationState" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>	      
+	  <parameter base="LastDataDownlinkRate" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+	  <parameter base="LastDataUplinkRate" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>            
+      <parameter base="SignalStrength" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+	  <parameter base="Retransmissions" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Active" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object> 
+	<object base="Device.WiFi.EndPoint.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="Disabled"/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ProfileReference" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="1">
+        <syntax>
+          <string/>
+          <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+      <parameter base="SSIDReference" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+	  <parameter base="ProfileNumberOfEntries" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object>      
+    <object base="Device.WiFi.EndPoint.{i}.Stats." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"> 
+	  <parameter base="LastDataDownlinkRate" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>      
+	  <parameter base="LastDataUplinkRate" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="SignalStrength" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>      
+	  <parameter base="Retransmissions" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+    </object>    
+    <object base="Device.WiFi.EndPoint.{i}.Security." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="ModesSupported" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ModesEnabled" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+	<object base="Device.WiFi.EndPoint.{i}.Profile.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+          <default type="factory" value="Disabled"/>
+        </syntax>
+      </parameter>
+      <parameter base="Alias" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="SSID" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Location" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+	  <parameter base="Priority" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <unsignedInt/>
+          <default type="factory" value="0"/>
+        </syntax>
+      </parameter>
+    </object>      
+    <object base="Device.WiFi.EndPoint.{i}.Profile.{i}.Security." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="ModeEnabled" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="WEPKey" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <hexBinary/>
+        </syntax>
+      </parameter>
+      <parameter base="PreSharedKey" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <hexBinary/>
+        </syntax>
+      </parameter>
+      <parameter base="KeyPassphrase" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>                  
+    </object>
+    <object base="Device.WiFi.EndPoint.{i}.WPS." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <boolean/>
+          <default type="factory" value="1"/>
+        </syntax>
+      </parameter>
+      <parameter base="ConfigMethodsSupported" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ConfigMethodsEnabled" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="1">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+  </object>
+  <object base="Device.WiFi.X_RDKCENTRAL-COM_ClientRoaming." access="readonly" minEntries="1" addObjIdx="-1" delObjIdx="-1">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+          <syntax>
+             <boolean/>
+          </syntax>
+     </parameter>
+     <parameter base="PreAssn_BestThresholdLevel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+          <syntax>
+             <int/>
+          </syntax>
+     </parameter>
+     <parameter base="PreAssn_BestDeltaLevel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+          <syntax>
+             <unsignedInt/>
+          </syntax>
+     </parameter>
+     <parameter base="SelfSteer_OverrideEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <boolean/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_BestDeltaLevelConnected" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <unsignedInt/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_BestDeltaLevelDisconnected" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <unsignedInt/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_APcontrolThresholdLevel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <int/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_APcontrolTimeframe" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <unsignedInt/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_APcontrolBeaconsMissedTime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <unsignedInt/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_SelfSteerThresholdLevel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <int/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_SelfSteerTimeframe" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <unsignedInt/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_SelfSteerBeaconsMissedTime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <unsignedInt/>
+         </syntax>
+     </parameter>
+     <parameter base="PostAssn_BackOffTime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <unsignedInt/>
+         </syntax>
+     </parameter>
+     <parameter base="80211kvrEnable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+             <boolean/>
+         </syntax>
+     </parameter>
+  </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.PingTelemetry." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="StartTime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="EndTime" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="Type" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+      <parameter base="BurstCnt" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <unsignedInt/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppConfig." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="AppCnt" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <unsignedInt/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppConfig.App.{i}." access="readOnly" minEntries="0" maxEntries="unbounded" addObjIdx="0" delObjIdx="0">
+      <parameter base="AppName" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+      <parameter base="AppUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+	  <parameter base="AppSize" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.EnableHttpCDL." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.TR069support." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry." access="readOnly" minEntries="1" maxEntries="1"/>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.MessageBusSource." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKBROWSER2_CFG." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="BACKGROUND_MEM_USAGE_LOW_WATERMARK" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <unsignedInt/>
+        </syntax>
+      </parameter>
+      <parameter base="BACKGROUND_MEM_USAGE_HIGH_WATERMARK" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <unsignedInt/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKBROWSER2_CFG.HTML_APP_RESURRECTION_PERIOD." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="days" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <unsignedInt/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.PeriodicFWCheck." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.IDS." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="ScanTask" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CPC1960." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.TrafficShaping." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="TSserverUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ProtectX1Services." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CGROUP." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.SoundPlayer." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+	 <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MS12." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="DAPv2_Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="DE_Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BootstrapConfig." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UPnP." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UPnP.Refactor." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XRDsp." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XRDsp.XR19." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Configuration" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MTLS." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MTLS.mTlsVA." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CRL." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     <parameter base="DirectOCSP" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CredDwnld." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+     </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CredDwnld." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Use" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+     </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.PreferredNetworkInterface." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Network." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Network.AllowDisableDefaultNetwork." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.1080pGraphics." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKShell." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Packager." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"/>
+       <object base="Device.Time." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+       <parameter base="NTPServer1" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NTPServer2" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NTPServer3" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="TR69ACSConnectURL_dev" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="TR69ACSConnectURL" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="TR69CertLocation" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="TR69Key" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PartnerId" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+     <parameter base="ClearParam" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="PartnerName" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PartnerProductName" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NetflixESNprefix" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Server1" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Server2" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Server3" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Server4" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Enable" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RF4CE." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RF4CE.FF." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="RspIdle" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <int/> </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RF4CE.HostPacketDecryption." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Voice." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="AudioMode" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <int/> </syntax>
+      </parameter>
+      <parameter base="AudioTiming" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <int/> </syntax>
+      </parameter>
+      <parameter base="AudioConfidenceThreshold" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+      <parameter base="AudioDuckingLevel" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <string/> </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FWUpdate." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FWUpdate.AutoExcluded." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="XconfUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.HideStartupScreensOnRootAppConnect." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.Control." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="ClearDB" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+      <parameter base="ClearDBEnd" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax> <boolean/> </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MTLS." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MTLS.mTlsLogUpload." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MTLS.mTlsDCMUpload." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+     <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.LSA." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="AdCacheEnable" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ProgrammerEnable" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ByteRangeDownload" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PlacementReqUrl" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="PSNUrl" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.WarehouseHost." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="CName1" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+         </syntax>
+      </parameter>
+      <parameter base="CName2" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="CNameTail" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.FKPS." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="URL1" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="URL2" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NameSpaceUri" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="NameSpacePrefix" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="AuthMessage" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.AuthService." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Host" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.fog." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="ZeroDrmHost" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.JSPPCache." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <boolean/>
+         </syntax>
+       </parameter>
+      </object>
+      <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0" />
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.openrdk." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0" />
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.openrdk.DisplaySettings." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.openrdk.StoragemanagerService." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0" />
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com.comcast." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0" />
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com.comcast.stateObserver." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0" />
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.DeviceDiagnostics_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.activityMonitor." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.proxies." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.LoggingPreferences." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.userpreferences." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object> 
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.openrdk.videoApplicationEvents_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+      <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.ContinueWatchingService_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>     
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.WebSocketService." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>     
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.Warehouse." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>     
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.soundPlayer_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com.comcast.hdmiCec_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>     
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com.comcast.HDCPProfile." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com.comcast.hdmiInput_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>   
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NonRootSupport." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+     </object>     
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.openrdk.ControlService." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.ping_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.linearSegmentedAdvertising_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.screenCaptureService." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.systemService." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.openrdk.RemoteActionMappingService." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.AVInput." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.openrdk.vrexmanagerservice." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com.comcast.xcast_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.FrontPanelService." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.com.comcast.deviceProvisioning_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderSecurity." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.xre-receiver." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+       <parameter base="customPKSServerAddress" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+       <parameter base="flashVideoPlayerURL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+       <parameter base="flashOSMFVideoPlayerURL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+       <parameter base="aveVideoPlayerURL" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+       <parameter base="firstConnectUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+       <parameter base="xreUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+    </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.recorder." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="UpdateSchedule" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+      <parameter base="Status" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+      <parameter base="LongpollUrl" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <string/>
+        </syntax>
+      </parameter>
+     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.vodclient." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+       <parameter base="StunnelConnect" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+         <syntax>
+           <string/>
+         </syntax>
+       </parameter>
+    </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderProxy.org.rdk.dataCapture_1." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>                                                                                                                          
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
+  </model>
+</dm:document>


### PR DESCRIPTION
Reason for change: This is a generic data-model that can be used by
 all accelerator devices.
Test Procedure: Make sure tr181 calls are working fine.
Risks: None

Signed-off-by: jkuria217 <Josekutty_Kuriakose@cable.comcast.com>