### PR TITLE
RDKCOM-1764 : Added RFC entry for manual IP mode

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -3390,6 +3390,13 @@
       </parameter>
     </object>
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Network." access="readOnly" minEntries="1" maxEntries="1"/>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Network.ManualIPSettings." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+    </object>
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Network.AllowDisableDefaultNetwork." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
         <syntax>


### PR DESCRIPTION
Reason for change: Add the entry for manual IP override settings
Test Procedure: Ensure the entry works with tr181 request
Risks: Low

Signed-off-by: jkuria217 <Josekutty_Kuriakose@cable.comcast.com>