### PR TITLE
RDKCOM-1947 : Update telemetry root

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -9,6 +9,18 @@
         </syntax>
       </parameter>
     </object>    
+    <object base="Device.X_RDKCENTRAL-COM_T2." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+        <parameter base="ReportProfiles" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+      <parameter base="ReportProfilesMsgPack" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object> 
     <object base="Device.DeviceInfo." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
       <parameter base="Manufacturer" access="readOnly" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="1" setIdx="-1">
         <syntax>


### PR DESCRIPTION
Reason for change: This marker is required for datamodel to
        parse properly
Test Procedure: Ensure tr69hostif is coming up without any crashes during booup
Risks: Medium

Signed-off-by: Josekutty Kuriakose <joseinweb@gmail.com>