### PR TITLE
KAONRO1000-465: Enable ipv6 client support

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -4003,5 +4003,12 @@
         </syntax>  
       </parameter>
      </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DHCPv6Client." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+           <boolean/>
+        </syntax>  
+      </parameter>
+     </object>
   </model>
 </dm:document>


### PR DESCRIPTION
Reason for change: Added RFC for IPv6 client support in data-model.
Test Procedure: Enable respective RFC and verify.
Risks: Low

Signed-off-by: Arun Madhavan <arun_madhavan@comcast.com>