### PR TITLE
AMINO-68: Missing AutoReboot RFC

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -362,6 +362,18 @@
         </syntax>
       </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot." access="readOnly" minEntries="1" maxEntries="1" addObjIdx="-1" delObjIdx="-1">
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <boolean/>
+        </syntax>
+      </parameter>
+      <parameter base="fwDelayReboot" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
+        <syntax>
+          <int/>
+        </syntax>
+      </parameter>
+    </object>
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo." access="readOnly" minEntries="0" maxEntries="1" addObjIdx="0" delObjIdx="0">
      <parameter base="AccountID" access="readWrite" notification="0" maxNotification="2" rebootIdx="0" initIdx="1" getIdx="18000" setIdx="18001">
        <syntax>


### PR DESCRIPTION
Reason for change: Add missing AutoReboot. It causes device reboot
after predefined timeout on unsupported datamodel having devices.
Test Procedure: Change the default RFC configuration and verify.
Risks: Low
Source: RDKM
License: GPLV2
Upstream-Status: Pending

Signed-off-by: Arun Madhavan <arun_madhavan@comcast.com>