### PR TITLE
RDKDEV-778: DAB RFC support in data-model

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -499,6 +499,13 @@
             </syntax>
         </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DAB." access="readOnly" minEntries="0" maxEntries="1" >
+        <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+            <syntax>
+                <boolean/>
+            </syntax>
+        </parameter>
+    </object>
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UhdEnable." access="readOnly" minEntries="0" maxEntries="1" >
         <parameter base="Enable" access="writeOnly" notification="0" maxNotification="2" >
             <syntax>


### PR DESCRIPTION
Reason for change: Adding DAB RFC in data-model.xml.
Test Procedure: Please see ticket for details.
Risks: Low
Source: RDKM
License: Inherited
Upstream-Status: Pending
Priority: P3