### PR TITLE
RDKDEV-778: DAB RFC default value in data-model

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -503,6 +503,7 @@
         <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
             <syntax>
                 <boolean/>
+		<default type="factory" value="false"/>
             </syntax>
         </parameter>
     </object>


### PR DESCRIPTION
Reason for change: Adding DAB RFC default value in data-model.xml.
Test Procedure: Please see ticket.
Risks: None
Source: RDKM
License: Inherited
Upstream-Status: Pending
Priority: P3