### PR TITLE
RDKUI-582: RFC Support for FireboltRefUI

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -5161,5 +5161,13 @@
         </syntax>
       </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FireboltRefUI." access="readOnly" minEntries="0" maxEntries="1" >
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+        <syntax>
+          <boolean/>
+          <default type="factory" value="false"/>
+        </syntax>
+      </parameter>
+    </object>
   </model>
 </dm:document>


### PR DESCRIPTION
Reason for change: Added RFC support for controlling RefUI being launched bu ripple when its enabled.
Test Procedure: Trigger build and verify.
Risks: High
Source: RDKM
License: Inherited
Upstream-Status: Pending
Priority: P2