### PR TITLE
RDKVREFPLT-1724: RFC support for AppHibernate functionality in memcr

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -5176,5 +5176,12 @@
         </syntax>
       </parameter>
     </object>    
+   <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppHibernate." access="readOnly" minEntries="0" maxEntries="1" >
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >                                                                                                                    
+        <syntax>           
+          <boolean/>                                                        
+        </syntax>                                                                                             
+      </parameter>
+    </object>
   </model>
 </dm:document>


### PR DESCRIPTION
Reason for change: Added RFC support for AppHibernate functionality in memcr.
Test Procedure: build and verify..
Risks: low.
Signed-off-by: Dinesh_kumar2@comcast.com