### PR TITLE
RDKVREFPLT-2104: RFC support for AppHibernate functionality in memcr #32Rdk6main feature branch

### DIFF
--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -5169,5 +5169,12 @@
         </syntax>
       </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.SystemServices." access="readOnly" minEntries="1" maxEntries="1" >
+      <parameter base="FriendlyName" access="readWrite" notification="0" maxNotification="2" >
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
+    </object>
   </model>
 </dm:document>

--- a/generic/data-model.xml
+++ b/generic/data-model.xml
@@ -5161,5 +5161,13 @@
         </syntax>
       </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FireboltRefUI." access="readOnly" minEntries="0" maxEntries="1" >
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+        <syntax>
+          <boolean/>
+          <default type="factory" value="false"/>
+        </syntax>
+      </parameter>
+    </object>
   </model>
 </dm:document>


### PR DESCRIPTION
RDKVREFPLT-2104 - Integrate thunder 4.4 memcr patches to thunder 4.2, RDKShell memcr patches, datamodel & validation

Reason for change: Added RFC support for AppHibernate functionality in memcr.

Test Procedure: Build and verified

Risks: Low